### PR TITLE
Fix JS error due to missing element

### DIFF
--- a/download/download-pages.rkt
+++ b/download/download-pages.rkt
@@ -792,7 +792,7 @@ var property = null;
            }
            null)
 
-      @(if (version<=? version-before-m1-support version)
+      @(if (version<? version-before-m1-support version)
            @list{
                  @; showWhen('m1_mac_explain', platform === 'x86_64-macosx');
                  showWhen('intel_mac_explain', platform === 'aarch64-macosx');


### PR DESCRIPTION
The conditions to show the explanation for m1 support are inconsistent. The one that triggers the explanation uses version<=? and the one that creates the explanation uses version<?. Therefore, when the version is exactly version-before-m1-support, it attempts to show the explanation that doesn't exist.

This PR makes the adjustment to make the conditions consistent. Based on the name `version-before-m1-support`,
version<? seems to be the right one to use.

Fixes #336